### PR TITLE
ci: update GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,25 +12,26 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
-        name: Checkout code
-      - name: Cache Gradle dependencies
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+      - name: Checkout code
+        uses: actions/checkout@v4
+        
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
+          
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      - name: Run lint
+        run: ./gradlew lint
+
       - name: Run tests
         run: ./gradlew test
+
+      - name: Build debug APK
+        run: ./gradlew assembleDebug


### PR DESCRIPTION
- Update checkout action to v4
- Update setup-java action to v4 with JDK 11
- Add Gradle setup action v3 for better caching
- Remove manual Gradle caching in favor of setup-gradle action
- Add lint step before tests
- Add debug APK build step

🤖 Generated with [Claude Code](https://claude.ai/code)