### PR TITLE
update gradle wrapper and android gradle plugin to v8, jdk to 17, rename to openforhatebu

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v4
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
           
       - name: Setup Gradle

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,13 +3,14 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace = 'jp.sane.openforhatebu'
     compileSdk = 34
     defaultConfig {
         applicationId "jp.sane.openforhatebu"
         minSdkVersion 24
         targetSdkVersion 34
-        versionCode 5000001
-        versionName "5.0.1"
+        versionCode 5000002
+        versionName "5.0.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -20,6 +21,13 @@ android {
     }
     buildFeatures {
         viewBinding = true
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
     }
 }
 

--- a/app/src/androidTest/java/jp/sane/openforhatebu/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/jp/sane/openforhatebu/ExampleInstrumentedTest.kt
@@ -1,4 +1,4 @@
-package jp.sane.openforhatenabookmark
+package jp.sane.openforhatebu
 
 import androidx.test.InstrumentationRegistry
 import androidx.test.runner.AndroidJUnit4
@@ -19,6 +19,6 @@ class ExampleInstrumentedTest {
     fun useAppContext() {
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getTargetContext()
-        assertEquals("jp.sane.openforhatenabookmark", appContext.packageName)
+        assertEquals("jp.sane.openforhatebu", appContext.packageName)
     }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="jp.sane.openforhatenabookmark">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET" />
     <application
@@ -26,6 +25,8 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+                <!-- Intentionally no host specified - this app handles all URLs -->
+                <!--suppress AppLinkUrlError -->
                 <data android:scheme="http" />
                 <data android:scheme="https" />
             </intent-filter>
@@ -34,6 +35,8 @@
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <category android:name="android.intent.category.DEFAULT" />
+                <!-- Intentionally no host specified - this app handles all URLs -->
+                <!--suppress AppLinkUrlError -->
                 <data android:scheme="http" />
                 <data android:scheme="https" />
                 <data android:mimeType="text/html"/>

--- a/app/src/main/java/jp/sane/openforhatebu/HatebuActivity.kt
+++ b/app/src/main/java/jp/sane/openforhatebu/HatebuActivity.kt
@@ -1,4 +1,4 @@
-package jp.sane.openforhatenabookmark
+package jp.sane.openforhatebu
 
 import android.content.Intent
 import android.net.Uri
@@ -15,7 +15,7 @@ import org.jsoup.Jsoup
 import java.net.URI
 import java.net.URL
 
-import jp.sane.openforhatenabookmark.databinding.ActivityHatebuBinding
+import jp.sane.openforhatebu.databinding.ActivityHatebuBinding
 
 class HatebuActivity : AppCompatActivity() {
     private lateinit var binding: ActivityHatebuBinding
@@ -68,7 +68,7 @@ suspend fun getCanonicalUri(html: String): URI? {
     Jsoup.parse(html).run {
         val links = getElementsByTag("link")
         for (i in 0 until links.count()) {
-            if (links[i].hasAttr("rel") && links[i].attr("rel").toLowerCase() == "canonical") {
+            if (links[i].hasAttr("rel") && links[i].attr("rel").lowercase() == "canonical") {
                 return URI(links[i].attr("href"))
             }
         }

--- a/app/src/main/java/jp/sane/openforhatebu/MainActivity.kt
+++ b/app/src/main/java/jp/sane/openforhatebu/MainActivity.kt
@@ -1,4 +1,4 @@
-package jp.sane.openforhatenabookmark
+package jp.sane.openforhatebu
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle

--- a/app/src/test/java/jp/sane/openforhatebu/ExampleUnitTest.kt
+++ b/app/src/test/java/jp/sane/openforhatebu/ExampleUnitTest.kt
@@ -1,4 +1,4 @@
-package jp.sane.openforhatenabookmark
+package jp.sane.openforhatebu
 
 import org.junit.Test
 

--- a/app/src/test/java/jp/sane/openforhatebu/HatebuUnitTest.kt
+++ b/app/src/test/java/jp/sane/openforhatebu/HatebuUnitTest.kt
@@ -1,4 +1,4 @@
-package jp.sane.openforhatenabookmark
+package jp.sane.openforhatebu
 
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.7.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Apr 18 19:43:30 WIB 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- chore: update Gradle wrapper and Android Gradle Plugin
- feat: add namespace for AGP 8.x compatibility
- refactor: migrate package name from openforhatenabookmark to openforhatebu
- fix: resolve lint errors in AndroidManifest.xml
- ci: update GitHub Actions to use JDK 17