### PR TITLE
chore: update dependencies and fix deprecated coroutines usage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,6 +39,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.8.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.7'
     implementation 'org.jsoup:jsoup:1.18.3'
     implementation "org.mozilla.components:support-utils:$mozilla_components_version"
     testImplementation 'junit:junit:4.13.2'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,14 +34,14 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.6.1'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
     implementation 'androidx.browser:browser:1.8.0'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.3'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
-    implementation 'org.jsoup:jsoup:1.13.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.9.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.9.0'
+    implementation 'org.jsoup:jsoup:1.18.3'
     implementation "org.mozilla.components:support-utils:$mozilla_components_version"
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test:runner:1.5.2'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test:runner:1.6.2'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/app/src/main/java/jp/sane/openforhatebu/HatebuActivity.kt
+++ b/app/src/main/java/jp/sane/openforhatebu/HatebuActivity.kt
@@ -7,9 +7,9 @@ import android.text.TextUtils
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsIntent
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import androidx.lifecycle.lifecycleScope
 import mozilla.components.support.utils.WebURLFinder
 import org.jsoup.Jsoup
 import java.net.URI
@@ -26,7 +26,7 @@ class HatebuActivity : AppCompatActivity() {
         when (intent.action) {
             Intent.ACTION_VIEW -> {
                 val uri = intent.data ?: return
-                GlobalScope.launch {
+                lifecycleScope.launch {
                     val targetUri = getTargetUri(URI(uri.toString()))
                     val entryUri = getEntryUri(targetUri)
                     withContext(Dispatchers.Main) {
@@ -43,7 +43,7 @@ class HatebuActivity : AppCompatActivity() {
                 if (TextUtils.isEmpty(dataString)) {
                     return
                 }
-                GlobalScope.launch {
+                lifecycleScope.launch {
                     val bestUrl = WebURLFinder(dataString).bestWebURL()
                     val targetUri = getTargetUri(URI(bestUrl))
                     val entryUri = getEntryUri(targetUri)


### PR DESCRIPTION
## Summary
- Update multiple dependencies to their latest stable versions
- Fix deprecated GlobalScope usage with lifecycleScope
- All builds and tests pass with updated dependencies

## Changes
### Dependency Updates
- **androidx.appcompat:appcompat**: 1.6.1 → 1.7.0
- **androidx.constraintlayout:constraintlayout**: 2.1.4 → 2.2.0
- **kotlinx-coroutines-core**: 1.7.3 → 1.9.0
- **kotlinx-coroutines-android**: 1.7.3 → 1.9.0
- **org.jsoup:jsoup**: 1.13.1 → 1.18.3
- **androidx.test:runner**: 1.5.2 → 1.6.2
- **androidx.test.espresso:espresso-core**: 3.5.1 → 3.6.1
- **androidx.lifecycle:lifecycle-runtime-ktx**: 2.8.7 (new)

### Code Fixes
- Replace deprecated `GlobalScope.launch` with `lifecycleScope.launch`
- Add proper lifecycle-aware coroutine scope management
- Ensure coroutines are cancelled when Activity is destroyed

## Test plan
- [x] Run clean build: `./gradlew clean build`
- [x] Verify all tests pass
- [x] Verify lint checks pass
- [x] No new warnings introduced
- [x] Coroutines properly managed with Activity lifecycle

🤖 Generated with [Claude Code](https://claude.ai/code)