### PR TITLE
feat(ui): support notch display cutout for fullscreen experience

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
             android:usesCleartextTraffic="true"
     >
         <activity android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@style/AppTheme.FullScreen">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 
@@ -20,7 +21,8 @@
             </intent-filter>
         </activity>
         <activity android:name=".HatebuActivity"
-            android:exported="true">
+            android:exported="true"
+            android:theme="@style/AppTheme.FullScreen">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/app/src/main/res/values-v27/styles.xml
+++ b/app/src/main/res/values-v27/styles.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme.FullScreen" parent="AppTheme">
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+</resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,4 +8,8 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
+    <style name="AppTheme.FullScreen" parent="AppTheme">
+        <!-- Base theme for all API levels -->
+    </style>
+
 </resources>


### PR DESCRIPTION
## Summary
- Add windowLayoutInDisplayCutoutMode shortEdges for API 27+ devices
- Apply FullScreen theme to MainActivity and HatebuActivity  
- Enables app to use notch area on compatible devices for better fullscreen experience

## Test plan
- Build and test on API 27+ devices with notch displays
- Verify backward compatibility on API 24-26 devices
- Confirm fullscreen layout utilizes entire screen area including notch region

🤖 Generated with [Claude Code](https://claude.ai/code)