### PR TITLE
chore(test): update deprecated AndroidJUnit4 to androidx.test.ext.junit

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'org.jsoup:jsoup:1.18.3'
     implementation "org.mozilla.components:support-utils:$mozilla_components_version"
     testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test:runner:1.6.2'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
 }

--- a/app/src/androidTest/java/jp/sane/openforhatebu/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/jp/sane/openforhatebu/ExampleInstrumentedTest.kt
@@ -1,7 +1,7 @@
 package jp.sane.openforhatebu
 
-import androidx.test.InstrumentationRegistry
-import androidx.test.runner.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.test.ext.junit.runners.AndroidJUnit4
 
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -18,7 +18,7 @@ class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
         // Context of the app under test.
-        val appContext = InstrumentationRegistry.getTargetContext()
+        val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         assertEquals("jp.sane.openforhatebu", appContext.packageName)
     }
 }


### PR DESCRIPTION
## Summary
- Replace deprecated AndroidJUnit4 with modern androidx.test.ext.junit runners
- Update InstrumentationRegistry to platform-specific version  
- Add androidx.test.ext:junit dependency for compatibility

## Test plan
- Verify build succeeds with updated dependencies
- Confirm instrumented test compilation works correctly
- Check that test structure follows current AndroidX testing practices

🤖 Generated with [Claude Code](https://claude.ai/code)