### PR TITLE
chore(deps): remove redundant kotlin-stdlib-jdk7 dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,6 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.0'
     implementation 'androidx.browser:browser:1.8.0'


### PR DESCRIPTION
## Summary
- Remove redundant kotlin-stdlib-jdk7 dependency as it's automatically included by Kotlin plugin in modern Android projects
- Cleans up explicit dependency declarations while maintaining functionality

## Test plan
- Build verification confirms all functionality intact without explicit stdlib dependency
- All tests pass and compile correctly
- Reduces dependency graph complexity

🤖 Generated with [Claude Code](https://claude.ai/code)