### PR TITLE
chore: bump version to 5.0.4

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "jp.sane.openforhatebu"
         minSdkVersion 24
         targetSdkVersion 35
-        versionCode 5000003
-        versionName "5.0.3"
+        versionCode 5000004
+        versionName "5.0.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,30 @@
+<a name="5.0.4"></a>
+## 5.0.4 (2025-07-19)
+
+- Refactor: migrate from Uri.parse() to toUri() extension
+- Feat: support notch display cutout for fullscreen experience  
+- Chore: update deprecated AndroidJUnit4 to androidx.test.ext.junit
+- Chore: remove redundant kotlin-stdlib-jdk7 dependency
+- Fix: replace GlobalScope with lifecycleScope
+- Chore: update dependencies to latest versions
+
+<a name="5.0.3"></a>
+## 5.0.3 (2025-07-15)
+
+- Feat: update JDK to 21 in build configuration
+- CI: update GitHub Actions to use JDK 21
+- Feat: update target SDK to 35
+- CI: update GitHub Actions to use JDK 17
+- Fix: resolve lint errors in AndroidManifest.xml
+- Refactor: migrate package name from openforhatenabookmark to openforhatebu
+- Feat: add namespace for AGP 8.x compatibility
+- Chore: update Gradle wrapper and Android Gradle Plugin
+- CI: update GitHub Actions workflow
+- Feat: add CLAUDE.md and ignore .claude/ directory
+
+<a name="5.0.2"></a>
+## 5.0.2 (2024-04-19)
+
 <a name="5.0.1"></a>
 ## 5.0.1 (2024-04-19)
 


### PR DESCRIPTION
## Summary
- Increment patch version from 5.0.3 to 5.0.4
- Update versionCode from 5000003 to 5000004
- Update changelog with new entries for 5.0.4 and 5.0.3

🤖 Generated with [Claude Code](https://claude.ai/code)