### PR TITLE
fix: move network call to IO dispatcher to prevent NetworkOnMainThreadException

### DIFF
--- a/app/src/main/java/jp/sane/openforhatebu/HatebuActivity.kt
+++ b/app/src/main/java/jp/sane/openforhatebu/HatebuActivity.kt
@@ -61,7 +61,9 @@ class HatebuActivity : AppCompatActivity() {
 }
 
 suspend fun getTargetUri(uri: URI): URI {
-    return getCanonicalUri(URL(uri.toString()).readText()) ?: uri
+    return withContext(Dispatchers.IO) {
+        getCanonicalUri(URL(uri.toString()).readText()) ?: uri
+    }
 }
 
 suspend fun getCanonicalUri(html: String): URI? {


### PR DESCRIPTION
## Summary
- Fixed NetworkOnMainThreadException that occurred when opening URLs on real devices
- Wrapped the `URL.readText()` network call with `withContext(Dispatchers.IO)` to execute it on a background thread instead of the main UI thread

## Test plan
- [x] Built and tested debug APK on real device via Wi-Fi debugging
- [x] Confirmed the NetworkOnMainThreadException no longer occurs
- [x] App successfully opens URLs and redirects to Hatena Bookmark entries

🤖 Generated with [Claude Code](https://claude.ai/code)