### PR TITLE
feat: add StrictMode for debug builds to catch threading violations

### DIFF
--- a/app/src/main/java/jp/sane/openforhatebu/HatebuActivity.kt
+++ b/app/src/main/java/jp/sane/openforhatebu/HatebuActivity.kt
@@ -2,6 +2,7 @@ package jp.sane.openforhatebu
 
 import android.content.Intent
 import android.os.Bundle
+import android.os.StrictMode
 import android.text.TextUtils
 import androidx.appcompat.app.AppCompatActivity
 import androidx.browser.customtabs.CustomTabsIntent
@@ -22,6 +23,11 @@ class HatebuActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        
+        if (BuildConfig.DEBUG) {
+            StrictMode.enableDefaults()
+        }
+        
         binding = ActivityHatebuBinding.inflate(layoutInflater)
         when (intent.action) {
             Intent.ACTION_VIEW -> {

--- a/app/src/main/java/jp/sane/openforhatebu/MainActivity.kt
+++ b/app/src/main/java/jp/sane/openforhatebu/MainActivity.kt
@@ -2,11 +2,17 @@ package jp.sane.openforhatebu
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.os.StrictMode
 
 class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        
+        if (BuildConfig.DEBUG) {
+            StrictMode.enableDefaults()
+        }
+        
         setContentView(R.layout.activity_main)
     }
 }


### PR DESCRIPTION
## Summary
- Added `StrictMode.enableDefaults()` to debug builds in both MainActivity and HatebuActivity
- Helps catch threading violations like NetworkOnMainThreadException during development
- Only enables StrictMode for debug builds to avoid affecting release performance

## Test plan
- [x] Verified StrictMode is only enabled when `BuildConfig.DEBUG` is true
- [x] Confirmed this would have caught the NetworkOnMainThreadException earlier in development
- [x] Tested that builds complete successfully with the changes

This will help prevent similar threading issues from reaching production by detecting them early in the development cycle.

🤖 Generated with [Claude Code](https://claude.ai/code)