### PR TITLE
fix: set explicit status bar color to prevent white status bar

### DIFF
--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -10,6 +10,8 @@
 
     <style name="AppTheme.FullScreen" parent="AppTheme">
         <!-- Base theme for all API levels -->
+        <item name="android:statusBarColor">@color/colorPrimaryDark</item>
+        <item name="android:windowLightStatusBar">false</item>
     </style>
 
 </resources>


### PR DESCRIPTION
## Summary
- Added explicit `statusBarColor` and `windowLightStatusBar` settings to `AppTheme.FullScreen`
- Fixes issue where status bar was displaying as white instead of the intended dark green
- Ensures consistent branding and proper visibility of status bar icons

## Changes
- `statusBarColor`: Set to `@color/colorPrimaryDark` for dark green background
- `windowLightStatusBar`: Set to `false` to display white text/icons on dark background

## Test plan
- [x] Verified settings are compatible with minSdk 24 (API 21+ for statusBarColor, API 23+ for windowLightStatusBar)
- [x] Confirmed this provides explicit control over status bar appearance
- [x] Status bar should now display consistently across different Android versions

🤖 Generated with [Claude Code](https://claude.ai/code)