### PR TITLE
chore: bump version to 5.0.5

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "jp.sane.openforhatebu"
         minSdkVersion 24
         targetSdkVersion 35
-        versionCode 5000004
-        versionName "5.0.4"
+        versionCode 5000005
+        versionName "5.0.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,10 @@
+<a name="5.0.5"></a>
+## 5.0.5 (2025-07-20)
+
+- Fix: resolve NetworkOnMainThreadException by moving network calls to IO dispatcher
+- Fix: improve status bar visibility with proper text/icon contrast
+- Feat: add StrictMode for debug builds to catch threading violations early
+
 <a name="5.0.4"></a>
 ## 5.0.4 (2025-07-19)
 


### PR DESCRIPTION
## Summary
Version bump to 5.0.5 with changelog update for recent bug fixes and improvements.

## Changes
- **Version**: Updated from 5.0.4 to 5.0.5
- **versionCode**: Updated from 5000004 to 5000005
- **Changelog**: Added entries for 5.0.5 release

## 5.0.5 Release Notes
- **Fix**: Resolve NetworkOnMainThreadException by moving network calls to IO dispatcher
- **Fix**: Improve status bar visibility with proper text/icon contrast
- **Feat**: Add StrictMode for debug builds to catch threading violations early

## Included Fixes
This version includes merged fixes from recent PRs:
- #49: NetworkOnMainThreadException fix
- #50: StrictMode for debug builds
- #51: Status bar visibility improvements

🤖 Generated with [Claude Code](https://claude.ai/code)