### PR TITLE
refactor: use IO dispatcher by default for lifecycleScope to prevent main thread blocking

### DIFF
--- a/app/src/main/java/jp/sane/openforhatebu/HatebuActivity.kt
+++ b/app/src/main/java/jp/sane/openforhatebu/HatebuActivity.kt
@@ -32,14 +32,14 @@ class HatebuActivity : AppCompatActivity() {
         when (intent.action) {
             Intent.ACTION_VIEW -> {
                 val uri = intent.data ?: return
-                lifecycleScope.launch {
+                lifecycleScope.launch(Dispatchers.IO) {
                     val targetUri = getTargetUri(URI(uri.toString()))
                     val entryUri = getEntryUri(targetUri)
                     withContext(Dispatchers.Main) {
                         binding.openingURI.text = entryUri.toString()
-                    }
-                    CustomTabsIntent.Builder().build().apply {
-                        launchUrl(this@HatebuActivity, entryUri.toString().toUri())
+                        CustomTabsIntent.Builder().build().apply {
+                            launchUrl(this@HatebuActivity, entryUri.toString().toUri())
+                        }
                     }
 
                 }
@@ -49,15 +49,15 @@ class HatebuActivity : AppCompatActivity() {
                 if (TextUtils.isEmpty(dataString)) {
                     return
                 }
-                lifecycleScope.launch {
+                lifecycleScope.launch(Dispatchers.IO) {
                     val bestUrl = WebURLFinder(dataString).bestWebURL()
                     val targetUri = getTargetUri(URI(bestUrl))
                     val entryUri = getEntryUri(targetUri)
                     withContext(Dispatchers.Main) {
                         binding.openingURI.text = entryUri.toString()
-                    }
-                    CustomTabsIntent.Builder().build().apply {
-                        launchUrl(this@HatebuActivity, entryUri.toString().toUri())
+                        CustomTabsIntent.Builder().build().apply {
+                            launchUrl(this@HatebuActivity, entryUri.toString().toUri())
+                        }
                     }
                 }
             }
@@ -67,9 +67,7 @@ class HatebuActivity : AppCompatActivity() {
 }
 
 suspend fun getTargetUri(uri: URI): URI {
-    return withContext(Dispatchers.IO) {
-        getCanonicalUri(URL(uri.toString()).readText()) ?: uri
-    }
+    return getCanonicalUri(URL(uri.toString()).readText()) ?: uri
 }
 
 suspend fun getCanonicalUri(html: String): URI? {


### PR DESCRIPTION
## Summary
- Change from Main dispatcher to IO dispatcher by default for heavy operations
- Move CustomTabsIntent.launchUrl() to Main dispatcher context for UI operations  
- Remove redundant withContext(Dispatchers.IO) from getTargetUri()

## Background
After commit `1f8b364` (GlobalScope → lifecycleScope), the default dispatcher changed from `Dispatchers.Default` to `Dispatchers.Main`. This caused potential ANR issues as heavy operations like Jsoup.parse() and WebURLFinder started running on the main thread.

## Changes Made
1. **lifecycleScope.launch** → **lifecycleScope.launch(Dispatchers.IO)** (2 locations)
2. **Move CustomTabsIntent.launchUrl()** inside existing `withContext(Dispatchers.Main)` blocks
3. **Remove redundant withContext(Dispatchers.IO)** from `getTargetUri()` function

## Benefits
- **Fail-safe**: Default behavior prevents main thread blocking
- **Scalable**: New heavy operations are safe by default  
- **Clear responsibility**: Heavy work on IO, UI updates explicitly on Main
- **Consistent**: Restores original GlobalScope behavior with better lifecycle management

## Test plan
- [x] Build passes
- [x] Unit tests pass
- [ ] Manual testing on device for both ACTION_VIEW and ACTION_SEND intents
- [ ] Verify no ANR occurs with large HTML pages
- [ ] Confirm UI updates work correctly

## Resolves
- Closes #58 (Jsoup.parse ANR)
- Closes #59 (WebURLFinder ANR)  
- Closes #60 (IO dispatcher by default)

🤖 Generated with [Claude Code](https://claude.ai/code)