### PR TITLE
fix: improve status bar visibility on Android 15 (API 35)

### DIFF
--- a/app/src/main/res/values-v35/styles.xml
+++ b/app/src/main/res/values-v35/styles.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="AppTheme.FullScreen" parent="AppTheme">
+        <!-- Android 15 (API 35) specific settings -->
+        <item name="android:statusBarColor">@color/colorPrimaryDark</item>
+        <item name="android:windowLightStatusBar">true</item>
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <!-- Additional settings for better visibility -->
+        <item name="android:navigationBarColor">@color/colorPrimaryDark</item>
+    </style>
+</resources>


### PR DESCRIPTION
## Summary
- Add Android 15 (API 35) specific styling to improve status bar readability
- Resolve white status bar text visibility issue on ASUS ZenFone

## Problem
On Android 15 devices (specifically ASUS ZenFone), the status bar text was completely white and unreadable due to insufficient contrast with the system background.

## Solution
- **Created `values-v35/styles.xml`** for Android 15 specific styling
- **Set `windowLightStatusBar="true"`** to use dark text/icons on light background
- **Maintained `colorPrimaryDark`** background color for consistency
- **Added `navigationBarColor`** for unified appearance

## Testing
- ✅ Tested on ASUS ZenFone (Android 15, API 35)
- ✅ Status bar text is now readable
- ✅ Maintains app design consistency
- ✅ No impact on older Android versions

## Technical Details
Android 15 introduced changes to status bar behavior that require explicit styling for optimal visibility. This fix targets API 35+ while preserving backward compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)