### PR TITLE
chore: bump version to 5.0.6

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,8 +9,8 @@ android {
         applicationId "jp.sane.openforhatebu"
         minSdkVersion 24
         targetSdkVersion 35
-        versionCode 5000005
-        versionName "5.0.5"
+        versionCode 5000006
+        versionName "5.0.6"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+<a name="5.0.6"></a>
+## 5.0.6 (2025-07-21)
+
+- Fix: improve status bar visibility on Android 15 (API 35) with proper text contrast
+- Refactor: use IO dispatcher by default for lifecycleScope to prevent main thread blocking
+- Performance: automatically fix ANR issues with Jsoup.parse() and WebURLFinder operations
+- Maintainability: make heavy operations safe by default for future development
+
 <a name="5.0.5"></a>
 ## 5.0.5 (2025-07-20)
 


### PR DESCRIPTION
## Summary
- Bump version from 5.0.5 to 5.0.6
- Update changelog with recent improvements

## Changes Included in 5.0.6
- **🔧 Fix**: Android 15 (API 35) status bar visibility improvements
- **⚡ Performance**: IO dispatcher by default to prevent main thread blocking  
- **🚀 ANR Prevention**: Automatic fix for Jsoup.parse() and WebURLFinder operations
- **🛠️ Maintainability**: Heavy operations are now safe by default

## Technical Details
- `versionName`: 5.0.5 → 5.0.6
- `versionCode`: 5000005 → 5000006  
- Added changelog entries for merged PRs #61 and #62

## Test plan
- [x] Version numbers updated correctly
- [x] Changelog reflects all recent changes
- [x] Build and release process validation

🤖 Generated with [Claude Code](https://claude.ai/code)